### PR TITLE
session: Add --port-forward flag for accessing monitor

### DIFF
--- a/kubenetbench/cmd/root.go
+++ b/kubenetbench/cmd/root.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	quiet       bool
-	sessID      string
-	sessDirBase string
+	quiet           bool
+	sessID          string
+	sessDirBase     string
+	sessPortForward bool
 )
 
 // var noCleanup bool
@@ -29,7 +30,7 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "initalize a seasson",
 	Run: func(cmd *cobra.Command, args []string) {
-		sess, err := core.InitSession(sessID, sessDirBase)
+		sess, err := core.InitSession(sessID, sessDirBase, sessPortForward)
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error initializing session: %w", err))
 		}
@@ -65,6 +66,7 @@ func init() {
 	rootCmd.MarkPersistentFlagRequired("session-id")
 	rootCmd.PersistentFlags().StringVarP(&sessDirBase, "session-base-dir", "d", ".", "base directory to store session data")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "quiet output")
+	rootCmd.PersistentFlags().BoolVarP(&sessPortForward, "port-forward", "", false, "use port-forward to connect to monitor")
 
 	// session commands
 	rootCmd.AddCommand(initCmd)
@@ -77,7 +79,7 @@ func init() {
 
 // return a session based on the given flags
 func getSession() *core.Session {
-	sess, err := core.NewSession(sessID, sessDirBase)
+	sess, err := core.NewSession(sessID, sessDirBase, sessPortForward)
 	if err != nil {
 		log.Fatal(fmt.Errorf("error creating session: %w", err))
 	}

--- a/kubenetbench/core/session.go
+++ b/kubenetbench/core/session.go
@@ -9,19 +9,22 @@ import (
 
 // SessionCtx is the context for a session run
 type Session struct {
-	id  string // id identifies the run
-	dir string // directory to store results/etc.
+	id          string // id identifies the run
+	dir         string // directory to store results/etc.
+	portForward bool   // use kubectl port-forward to connect to the monitor
 }
 
 // NewRunCtx creates a new RunCtx
 func NewSession(
 	sessId string,
 	sessDirBase string,
+	sessPortForward bool,
 ) (*Session, error) {
 
 	sess := &Session{
-		id:  sessId,
-		dir: fmt.Sprintf("%s/%s", sessDirBase, sessId),
+		id:          sessId,
+		dir:         fmt.Sprintf("%s/%s", sessDirBase, sessId),
+		portForward: sessPortForward,
 	}
 
 	info, err_stat := os.Stat(sess.dir)
@@ -44,11 +47,13 @@ func NewSession(
 func InitSession(
 	sessId string,
 	sessDirBase string,
+	sessPortForward bool,
 ) (*Session, error) {
 
 	sess := &Session{
-		id:  sessId,
-		dir: fmt.Sprintf("%s/%s", sessDirBase, sessId),
+		id:          sessId,
+		dir:         fmt.Sprintf("%s/%s", sessDirBase, sessId),
+		portForward: sessPortForward,
 	}
 
 	info, err_stat := os.Stat(sess.dir)
@@ -86,7 +91,7 @@ func (s *Session) writeScript(sid, sdbase string) {
 
 	fmt.Fprintln(f, "#!/bin/sh")
 	fmt.Fprintln(f, "# wrapper script for kubenetbench")
-	fmt.Fprintf(f, "%s --session-id %s --session-base-dir %s \"$@\"\n", prog, sid, sdbase)
+	fmt.Fprintf(f, "%s --session-id=%s --session-base-dir=%s --port-forward=%t \"$@\"\n", prog, sid, sdbase, s.portForward)
 
 	err = os.Chmod(fname, 0755)
 	if err != nil {


### PR DESCRIPTION
This adds a new persistent command-line flag called `--port-forward`. When it is
set, then the monitor is accessed via `kubectl port-forward` instead of
via node IP. This is useful in setups where node IPs are not directly
accessable from the test driver machine, for example if the nodes under
test run on GKE.

Example:
```console
$ ./kubenetbench/kubenetbench --port-forward -s test init
2021/01/19 17:43:28 ================> wrote wrapper script: you may use: ./test/knb
2021/01/19 17:43:28 ****** ./kubenetbench/kubenetbench --port-forward -s test init
2021/01/19 17:43:28 Starting session monitor
2021/01/19 17:43:28 Generating ./test/monitor.yaml
2021/01/19 17:43:28 $ kubectl apply -f ./test/monitor.yaml
2021/01/19 17:43:29 calling GetSysInfoNode on gke-sebastian-perf-test--default-pool-b46cc426-0gqw/10.172.0.45 (remaining retries: 10)
2021/01/19 17:43:29 $ kubectl get pods -l "role=monitor,knb-sessid=test" --field-selector=spec.nodeName="gke-sebastian-perf-test--default-pool-b46cc426-0gqw" -o custom-columns=Name:'.metadata.name' --no-headers
2021/01/19 17:43:29 $ kubectl port-forward knb-monitor-zk4qx :8451
2021/01/19 17:43:43 calling GetSysInfoNode on gke-sebastian-perf-test--default-pool-b46cc426-0gqw/10.172.0.45 (remaining retries: 9)
2021/01/19 17:43:43 $ kubectl get pods -l "role=monitor,knb-sessid=test" --field-selector=spec.nodeName="gke-sebastian-perf-test--default-pool-b46cc426-0gqw" -o custom-columns=Name:'.metadata.name' --no-headers
2021/01/19 17:43:43 $ kubectl port-forward knb-monitor-zk4qx :8451
2021/01/19 17:43:44 calling GetSysInfoNode on gke-sebastian-perf-test--default-pool-b46cc426-4gpd/10.172.0.44 (remaining retries: 10)
2021/01/19 17:43:44 $ kubectl get pods -l "role=monitor,knb-sessid=test" --field-selector=spec.nodeName="gke-sebastian-perf-test--default-pool-b46cc426-4gpd" -o custom-columns=Name:'.metadata.name' --no-headers
2021/01/19 17:43:44 $ kubectl port-forward knb-monitor-xvnsd :8451
```

Signed-off-by: Sebastian Wicki <sebastian@isovalent.com>